### PR TITLE
modules: schema names: add missing schema names

### DIFF
--- a/src/update/index.js
+++ b/src/update/index.js
@@ -54,6 +54,8 @@ const additionalModuleDependencies = {
 const moduleSchemaVersionNames = {
     capture: 'capture_schema',
     workflow_manager: 'mywmywwfm_schema',
+    mywapp_common: 'mywapp_schema',
+	groups: 'groups',
     survey: 'mywis_schema',
     gas: 'mywgas_schema',
     electric: 'iqg_electric_schema',

--- a/src/update/index.js
+++ b/src/update/index.js
@@ -55,7 +55,7 @@ const moduleSchemaVersionNames = {
     capture: 'capture_schema',
     workflow_manager: 'mywmywwfm_schema',
     mywapp_common: 'mywapp_schema',
-	groups: 'groups',
+    groups: 'groups',
     survey: 'mywis_schema',
     gas: 'mywgas_schema',
     electric: 'iqg_electric_schema',


### PR DESCRIPTION
groups and mywapp_common both have schema that need to be installed.

Groups is required for workflow_manager v3.1 and the soon to be released survey 6.0

mywapp_common is needed by survey
