### PR TITLE
PLAT-11001: transform: module injection: remove --link when using COPY --from

### DIFF
--- a/src/update/transform.js
+++ b/src/update/transform.js
@@ -231,7 +231,7 @@ function replaceModuleInjection(content, modules, isDevEnv = false) {
         .filter(copyFilter)
         .map(({ name, version }) =>
             version
-                ? `COPY --link --from=${name} / \${MODULES}/`
+                ? `COPY --from=${name} / \${MODULES}/`
                 : `COPY --link ${name} \${MODULES}/${name}`
         )
         .join('\n');


### PR DESCRIPTION
Would cause permission issues when used with containerd image stores. 
And --link doesn't make much sense when using --from
