### PR TITLE
PLAT-11234: handle tsconfig.json

### DIFF
--- a/playground/utils-project-template/.devcontainer/docker-compose.yml
+++ b/playground/utils-project-template/.devcontainer/docker-compose.yml
@@ -74,6 +74,7 @@ services:
             - ../.gitignore:/opt/iqgeo/platform/WebApps/myworldapp/modules/.gitignore:delegated
             - ../.iqgeorc.jsonc:/opt/iqgeo/platform/WebApps/myworldapp/modules/.iqgeorc.jsonc:delegated
             - ../README.md:/opt/iqgeo/platform/WebApps/myworldapp/modules/README.md:delegated
+            - ../tsconfig.json.md:/opt/iqgeo/platform/WebApps/myworldapp/modules/tsconfig.json.md:delegated
 
             - js_bundles:/opt/iqgeo/platform/WebApps/myworldapp/public/bundles # to keep builds when container is recreated
 

--- a/playground/utils-project-template/.gitignore
+++ b/playground/utils-project-template/.gitignore
@@ -8,7 +8,6 @@ node_modules
 #files from platform that should be ignored (show as changed because of www-data ownership)
 /__init__.py
 /jsconfig.json
-/tsconfig.json
 /tsconfig.core.json
 
 # START SECTION Product modules

--- a/playground/utils-project-template/tsconfig.json
+++ b/playground/utils-project-template/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "extends": "./tsconfig.core.json",
+    "compilerOptions": {
+        "paths": {
+            "myWorld-base": ["../core/client/myWorld-client-namespace.js"],
+            "myWorld-client": ["../core/client/myWorld-client-namespace.js"],
+            "myWorld-client/react": ["../core/client/uiComponents/react"],
+            "myWorld-native-services": ["../core/native/native-client.js"],
+            "modules/dev_tools/*": ["./dev_tools/public/*"],
+            "modules/vector_tile_styles/*": ["./vector_tile_styles/public/*"],
+            "images/*": ["../core/client/images/*"],
+            "modules/custom/*": ["./custom/public/*"],
+            "modules/comms/*": ["./comms/public/*"]
+        }
+    }
+}

--- a/src/pull/index.js
+++ b/src/pull/index.js
@@ -34,6 +34,7 @@ import { compareIqgeorc, mergeCustomSections } from './diff.js';
  */
 const INCLUDE_FILES = [
     '.gitignore',
+    'tsconfig.json',
     '.devcontainer/dockerfile',
     '.devcontainer/docker-compose.yml',
     '.devcontainer/.env.example',

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -35,6 +35,7 @@
 /**
   @typedef {
     '.gitignore' |
+    'tsconfig.json' |
     '.devcontainer/dockerfile' |
     '.devcontainer/docker-compose.yml' |
     '.devcontainer/.env.example' |


### PR DESCRIPTION
There's a mismatch between how Webpack and TypeScript resolve module paths. Namely, `modules/<module>/*` is mapped to `./<module>/public/*`. This can't be fixed by defining static paths in [core](https://github.com/IQGeo/myworld-product-core/blob/master/WebApps/myworldapp/modules/tsconfig.core.json), because TypeScript only allows one wildcard in a path, so we can't do `./*/public/*`.

This PR adds tsconfig.json to the list of files pulled from the project-template and an update transformer that populates `compilerOptions.paths` with path mappings for the modules defined in .iqgeorc.jsonc.

https://github.com/IQGeo/utils-project-template/pull/46