### PR TITLE
feat(pull): support custom sections in jsonc files

### DIFF
--- a/src/pull/index.js
+++ b/src/pull/index.js
@@ -165,7 +165,13 @@ export async function pull({
             const projectFileStr = await fs.promises.readFile(`${out}/${filepath}`, 'utf8');
             if (templateFileStr === projectFileStr) return;
 
-            const mergedText = mergeCustomSections(templateFileStr, projectFileStr);
+            const isJsonc = filepath.endsWith('.jsonc') || filepath === 'tsconfig.json';
+
+            const mergedText = mergeCustomSections(
+                templateFileStr,
+                projectFileStr,
+                isJsonc ? '//' : '#'
+            );
 
             writeOps.push({
                 dest: `${out}/${filepath}`,


### PR DESCRIPTION
When running `pull`, any existing config in `tsconfig.json` is overwritten. This PR adds support for custom sections in jsonc files:

<img width="661" alt="Screenshot 2025-03-17 at 15 23 31" src="https://github.com/user-attachments/assets/bdde68f6-e44d-4312-bd8a-379a6dc61ca6" />
