### PR TITLE
DX-6: Enable Docker services for module-dependent services

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -66,6 +66,12 @@ const moduleToProjectMapping = Object.entries(projectToModuleMapping).reduce(
     /** @type {Record<string, string>} */ ({})
 );
 
+/** @type {Record<string, string[]>} */
+const moduleToServiceMapping = {
+    orchestration_manager: ['openbao'],
+    notification_manager: ['centrifugo']
+};
+
 /**
  * @param {string} root
  * @returns {Config}
@@ -110,6 +116,13 @@ export function readConfig(root) {
         if (module.dbInit === true && !module.schemaVersionName)
             module.schemaVersionName = `${module.name}_schema`;
     }
+
+    const requiredServices = new Set();
+    for (const { name } of config.modules) {
+        const services = moduleToServiceMapping[name];
+        if (services) services.forEach(s => requiredServices.add(s));
+    }
+    config.requiredServices = [...requiredServices];
 
     return config;
 }

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -33,6 +33,7 @@
  * @property {Module[]} modules
  * @property {string[]} [exclude_file_paths]
  * @property {string} version
+ * @property {string[]} [requiredServices] Docker Compose service names that must be enabled for the configured modules
  */
 
 /**

--- a/src/update/transform.js
+++ b/src/update/transform.js
@@ -69,6 +69,36 @@ const upgradeDbModifier = (config, content) => {
 };
 
 /**
+ * Enables named services in a Docker Compose file by removing their `profiles: ['disabled']` line
+ * and adding them to the `depends_on` section of the `iqgeo` service.
+ * If a service is not present in the file, the operation is a no-op for that service.
+ * @param {string} content
+ * @param {string[]} services
+ * @returns {string}
+ */
+function enableServices(content, services) {
+    for (const service of services) {
+        content = content.replace(
+            new RegExp(`(\n    ${service}:\n)        profiles: \\['disabled'\\]\n`),
+            '$1'
+        );
+    }
+    if (!services.length) return content;
+    return content.replace(/ {4}iqgeo:\n[\s\S]*?(?=\n {4}\w)/, serviceBlock =>
+        serviceBlock.replace(
+            /( {8}depends_on:\n)((?:( {12})- [^\n]+\n)*)/,
+            (_, header, entries) => {
+                const toAdd = services
+                    .filter(s => !entries.includes(`            - ${s}\n`))
+                    .map(s => `            - ${s}\n`)
+                    .join('');
+                return header + entries + toAdd;
+            }
+        )
+    );
+}
+
+/**
  * @satisfies {Partial<Record<TemplateFilePath, Transformer>>}
  */
 export const fileTransformers = {
@@ -126,6 +156,8 @@ export const fileTransformers = {
                     `            - ../${devSrc}:/opt/iqgeo/platform/WebApps/myworldapp/modules/${name}:delegated`
             )
             .join('\n');
+
+        content = enableServices(content, config.requiredServices ?? []);
 
         return content
             .replace(/(# START SECTION.*)[\s\S]*?(.*# END SECTION)/, `$1\n${newContent}\n$2`)
@@ -238,6 +270,8 @@ export const fileTransformers = {
         const { prefix, db_name } = config;
         const { deployment } = config;
         const { project_registry = '', project_repository = '' } = deployment || {};
+
+        content = enableServices(content, config.requiredServices ?? []);
 
         return content
             .replace(/\${PROJ_PREFIX(?::-[^}]*)?}/g, `\${PROJ_PREFIX:-${prefix}}`)


### PR DESCRIPTION
## Summary

When modules are configured in the project update script, Docker Compose services that those modules depend on are now automatically enabled. The `enableServices()` helper removes their `profiles: ['disabled']` entry and adds them to the `depends_on` section of the `iqgeo` service.

## Changes

**`src/config.js`**
- Added `moduleToServiceMapping` defining service dependencies per module:
  - `orchestration_manager` → `openbao`
  - `notification_manager` → `centrifugo`
- `readConfig()` now computes `requiredServices: string[]` from active modules using this mapping

**`src/typedef.js`**
- Added `@property {string[]} [requiredServices]` to the `Config` typedef

**`src/update/transform.js`**
- Added `enableServices(content, services)` helper that, for each required service:
  - Removes the `profiles: ['disabled']` line, enabling the service to run
  - Adds the service to the `depends_on` block of the `iqgeo` service (idempotent, no duplicates)
- Both `deployment/docker-compose.yml` and `.devcontainer/docker-compose.yml` transformers call `enableServices` with `config.requiredServices`

Relates to [DX-6](https://iqgeo.atlassian.net/browse/DX-6)

[DX-6]: https://iqgeo.atlassian.net/browse/DX-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Example of what will be in the docker-compose

```yaml
centrifugo:
        profiles: ['disabled']
        image: centrifugo/centrifugo:v6
        container_name: centrifugo_${PROJ_PREFIX:-myproj}
        restart: unless-stopped
        ports:
            - ${CENTRIFUGO_PORT:-8000}:8000
        command: centrifugo
        environment:
            CENTRIFUGO_ADMIN_PASSWORD: ${CENTRIFUGO_ADMIN_PASSWORD:-admin_password}
            CENTRIFUGO_HTTP_API_KEY: ${CENTRIFUGO_HTTP_API_KEY:-6b213c49-1baf-43ec-9ffd-28a69edf5514}
            CENTRIFUGO_ADMIN_SECRET: ${CENTRIFUGO_ADMIN_SECRET:-VJaNwhRxcO6T26Dk5YD}
            CENTRIFUGO_WEBSOCKET_HANDLER_PREFIX: ${CENTRIFUGO_WEBSOCKET_HANDLER_PREFIX:-/modules/notification_manager/websocket}
            CENTRIFUGO_CLIENT_ALLOWED_ORIGINS: ${CENTRIFUGO_CLIENT_ALLOWED_ORIGINS:-*}
            CENTRIFUGO_CLIENT_PROXY_CONNECT_ENABLED: ${CENTRIFUGO_CLIENT_PROXY_CONNECT_ENABLED:-true}
            CENTRIFUGO_CLIENT_PROXY_CONNECT_ENDPOINT: ${CENTRIFUGO_CLIENT_PROXY_CONNECT_ENDPOINT:-http://iqgeo:8080/modules/notification_manager/api/v1/authorize}
            CENTRIFUGO_CLIENT_PROXY_CONNECT_HTTP_HEADERS: ${CENTRIFUGO_CLIENT_PROXY_CONNECT_HTTP_HEADERS:-Cookie X-CSRF-Token}
            CENTRIFUGO_SWAGGER_ENABLED: ${CENTRIFUGO_SWAGGER_ENABLED:-true}
            CENTRIFUGO_ADMIN_ENABLED: ${CENTRIFUGO_ADMIN_ENABLED:-true}
            CENTRIFUGO_DEBUG_ENABLED: ${CENTRIFUGO_DEBUG_ENABLED:-true}
            CENTRIFUGO_LOG_LEVEL: ${CENTRIFUGO_LOG_LEVEL:-trace}

    openbao:
        profiles: ['disabled']
        image: openbao/openbao:latest
        restart: always
        container_name: openbao_${PROJ_PREFIX:-myproj}
        ports:
            - ${OPENBAO_PORT:-8200}:8200
        environment:
            OPENBAO_DEV_ROOT_TOKEN_ID: ${OPENBAO_DEV_ROOT_TOKEN_ID:-myroot}
            OPENBAO_DEV_LISTEN_ADDRESS: ${OPENBAO_DEV_LISTEN_ADDRESS:-0.0.0.0:8200}
        cap_add:
            - IPC_LOCK
        command: server -dev -dev-root-token-id="${OPENBAO_DEV_ROOT_TOKEN_ID:-myroot}"
        ```