### PR TITLE
fix: generate schemaVersionName for versioned modules without explicit dbInit

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -113,7 +113,7 @@ export function readConfig(root) {
         module.registryProject =
             module.registryProject ?? moduleToProjectMapping[module.name] ?? module.name;
 
-        if (module.dbInit === true && !module.schemaVersionName)
+        if ((module.dbInit ?? !!module.version) && !module.schemaVersionName)
             module.schemaVersionName = `${module.name}_schema`;
     }
 


### PR DESCRIPTION
## Problem

When adding `orchestration_manager` or `notification_manager` to a project's modules, no db init/upgrade commands were generated in `600_init_db.sh` / `610_upgrade_db.sh`.

**Root cause:** These modules have a `version` (so they implicitly default to `dbInit=true`) but are not listed in `moduleSchemaVersionNames`. The condition that generates a fallback `schemaVersionName` only fired when `dbInit === true` was explicitly set:

```js
if (module.dbInit === true && !module.schemaVersionName)
    module.schemaVersionName = `${module.name}_schema`;
```

Since `dbInit` was not explicitly set for these modules, `schemaVersionName` remained `undefined`, and the transform filter correctly excluded them from db init scripts.

## Fix

Use the same defaulting logic as the transform filter (`dbInit ?? !!module.version`):

```js
if ((module.dbInit ?? !!module.version) && !module.schemaVersionName)
    module.schemaVersionName = `${module.name}_schema`;
```

This ensures any versioned module without an explicit `schemaVersionName` in the lookup table gets a fallback name of `${module.name}_schema`, matching the existing behaviour for modules with `dbInit: true`.

**Affected modules:** `orchestration_manager` → `orchestration_manager_schema`, `notification_manager` → `notification_manager_schema` (and any future versioned modules in the same situation).