### PR TITLE
Add missing schema names for notification_manager and orchestration_manager

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -22,7 +22,9 @@ const moduleSchemaVersionNames = {
     comsof: 'iqg_comsof_schema',
     comms_cloud: 'iqg_comms_cloud_schema',
     network_revenue_optimizer: 'mywnro_schema',
-    pia_interface: 'myw_pia_schema'
+    pia_interface: 'myw_pia_schema',
+    notification_manager: 'mywnotif_schema',
+    orchestration_manager: 'iqgom_schema'
 };
 
 const projectToModuleMapping = {


### PR DESCRIPTION
The `moduleSchemaVersionNames` mapping in `src/config.js` is used to resolve schema version names for modules whose names don't follow the default `<module>_schema` convention. Two modules were missing entries, which would cause their schema version names to be derived incorrectly.

Adds the following mappings:
- `notification_manager` -> `mywnotif_schema`
- `orchestration_manager` -> `iqgom_schema`