### PR TITLE
fix: PLAT-13403 map comms_dev_tools to comms registry project

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,14 @@ const moduleSchemaVersionNames = {
 
 const projectToModuleMapping = {
     capture: ['capture'],
-    comms: ['comms', 'comms_dev_db', 'comms_cloud', 'comms_cloud_dev_db', 'comms_inside_plant'],
+    comms: [
+        'comms',
+        'comms_dev_db',
+        'comms_cloud',
+        'comms_cloud_dev_db',
+        'comms_inside_plant',
+        'comms_dev_tools'
+    ],
     comsof: ['comsof', 'comsof_dev_db'],
     electric: ['electric', 'electric_dev_db'],
     gas: ['gas', 'gas_dev_db'],


### PR DESCRIPTION
## Summary
- add `comms_dev_tools` to the `comms` registry project mapping in `src/config.js`
- keep module alias generation consistent for comms-related modules in generated Dockerfiles

## Problem
PLAT-13403 reported that generated aliases used an incorrect image path for `comms_dev_tools`, requiring manual fixes.

## Result
`comms_dev_tools` now resolves to the `comms` registry project, so generated aliases follow:
- `${PRODUCT_REGISTRY}...comms/comms_inside_plant:...`
- `${PRODUCT_REGISTRY}...comms/comms_dev_tools:...`
- `${PRODUCT_REGISTRY}...comms/comms_dev_db:...`

## Validation
- linted `src` with `npx eslint src --ext .js`
- reproduced alias generation with the PLAT-13403 module set and confirmed corrected output