### PR TITLE
DX-76: remove -dev suffix from SAML runtime apt deps

### DIFF
--- a/src/update/transform.js
+++ b/src/update/transform.js
@@ -10,7 +10,7 @@ const aptGetMappings = {
     runtime: {
         memcached: ['libmemcached11'],
         ldap: ['libsasl2-dev', 'libldap2-dev'], //ENH: identify the correct runtime packages
-        saml: ['libxml2-dev', 'libxmlsec1-dev'], //ENH: identify the correct runtime packages
+        saml: ['libxml2', 'libxmlsec1'], // runtime shared libraries (no -dev headers needed in final image)
         osm: ['osm2pgsql', 'osmctools']
     },
     dev: {


### PR DESCRIPTION
## Why

When `saml` is listed as a dependency in a project's `.iqgeorc` file, the project update tool injects apt packages into the generated `deployment/dockerfile.appserver`. The SAML `runtime` mapping was using the build-time `-dev` packages (`libxml2-dev`, `libxmlsec1-dev`), so those headers leaked into the final stage of the multi-stage appserver build where they are not needed. This bloats the runtime image and carries build-time vulnerabilities into the deployed appserver (see PLAT-14254).

## What changed

In `src/update/transform.js`, the `runtime` entry for `saml` now uses the runtime shared libraries (`libxml2`, `libxmlsec1`) instead of the `-dev` packages. The `build` mapping is unchanged and still installs the `-dev` headers, which the builder stage needs to compile.

## Notes

- The `dev` mapping is auto-computed as the union of `build` and `runtime`, so the devcontainer still gets the `-dev` headers required for local builds.
- Tracked in DX-76; related to PLAT-14254.