### PR TITLE
feat: support type: product module declaration in Dockerfile.build

### DIFF
--- a/src/typedef.js
+++ b/src/typedef.js
@@ -5,6 +5,7 @@
 /**
  * @typedef Module
  * @property {string} name
+ * @property {string} [type] Type of module (e.g. 'product' for product modules that are pulled from registry using VERSION build arg)
  * @property {string} [version]
  * @property {boolean} [devOnly]
  * @property {string} [devSrc]

--- a/src/update/transform.js
+++ b/src/update/transform.js
@@ -444,7 +444,7 @@ function replaceModuleInjection(content, config, isDevEnv = false) {
     /** @type {(module: Module) => boolean} */
     const fromAsFilter = isDevEnv
         ? isFromInjectorFn
-        : ({ version, devOnly }) => !!version && !devOnly;
+        : ({ version, devOnly, type }) => (!!version || type === 'product') && !devOnly;
 
     // use new registry paths only if version in jsonc file is higher than 0.6.0
     const isNewRegistry = version !== undefined && semver.gt(version, '0.6.0');
@@ -458,10 +458,13 @@ function replaceModuleInjection(content, config, isDevEnv = false) {
             : isNewRegistry
               ? `\${PRODUCT_REGISTRY}${registryProject}/`
               : `\${CONTAINER_REGISTRY}`;
-        return `FROM ${registryPath}${lname}:${version} AS ${lname}`;
+        const versionStr = version || `\${VERSION}`;
+        return `FROM ${registryPath}${lname}:${versionStr} AS ${lname}`;
     };
 
-    const section1 = modules.filter(fromAsFilter).map(fromStatement).join('\n');
+    const hasProductModules = !isDevEnv && modules.filter(fromAsFilter).some(({ type }) => type === 'product');
+    const argVersion = hasProductModules ? 'ARG VERSION\n' : '';
+    const section1 = argVersion + modules.filter(fromAsFilter).map(fromStatement).join('\n');
 
     const replacedContent = content.replace(
         /(# START SECTION Aliases for Injector images.*)[\s\S]*?(# END SECTION)/,
@@ -473,8 +476,8 @@ function replaceModuleInjection(content, config, isDevEnv = false) {
 
     const section2 = modules
         .filter(copyFilter)
-        .map(({ name, version }) =>
-            version
+        .map(({ name, version, type }) =>
+            version || type === 'product'
                 ? `COPY --from=${name.toLowerCase()} / \${MODULES}/`
                 : `COPY --link ${name} \${MODULES}/${name}`
         )

--- a/tests/transform.test.js
+++ b/tests/transform.test.js
@@ -243,6 +243,105 @@ describe('fileTransformers', () => {
             expect(result).toContain('platform-build:7.2.0');
             expect(result).not.toContain('platform-build:OLD');
         });
+
+        it('uses ${VERSION} for product modules without explicit version', () => {
+            const config = makeConfig({
+                modules: [
+                    { name: 'myproduct', type: 'product', isExternal: true, registryProject: 'myproduct' }
+                ]
+            });
+            const content = [
+                '# START SECTION Aliases for Injector images',
+                '# END SECTION',
+                '# START SECTION Copy the modules',
+                '# END SECTION',
+                'FROM harbor/platform-build:OLD'
+            ].join('\n');
+
+            const result = fileTransformers['deployment/dockerfile.build'](config, content);
+
+            expect(result).toContain('ARG VERSION');
+            expect(result).toContain('FROM ${PRODUCT_REGISTRY}myproduct/myproduct:${VERSION} AS myproduct');
+            expect(result).toContain('COPY --from=myproduct / ${MODULES}/');
+        });
+
+        it('does not add ARG VERSION when no product modules exist', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION Aliases for Injector images',
+                '# END SECTION',
+                '# START SECTION Copy the modules',
+                '# END SECTION',
+                'FROM harbor/platform-build:OLD'
+            ].join('\n');
+
+            const result = fileTransformers['deployment/dockerfile.build'](config, content);
+
+            expect(result).not.toContain('ARG VERSION');
+        });
+
+        it('product modules with explicit version use that version instead of ${VERSION}', () => {
+            const config = makeConfig({
+                modules: [
+                    { name: 'myproduct', type: 'product', version: '2.0.0', isExternal: true, registryProject: 'myproduct' }
+                ]
+            });
+            const content = [
+                '# START SECTION Aliases for Injector images',
+                '# END SECTION',
+                '# START SECTION Copy the modules',
+                '# END SECTION',
+                'FROM harbor/platform-build:OLD'
+            ].join('\n');
+
+            const result = fileTransformers['deployment/dockerfile.build'](config, content);
+
+            expect(result).toContain('FROM ${PRODUCT_REGISTRY}myproduct/myproduct:2.0.0 AS myproduct');
+            expect(result).toContain('COPY --from=myproduct / ${MODULES}/');
+        });
+
+        it('excludes devOnly product modules from build Dockerfile', () => {
+            const config = makeConfig({
+                modules: [
+                    { name: 'devtool', type: 'product', devOnly: true, isExternal: true, registryProject: 'devtool' }
+                ]
+            });
+            const content = [
+                '# START SECTION Aliases for Injector images',
+                '# END SECTION',
+                '# START SECTION Copy the modules',
+                '# END SECTION',
+                'FROM harbor/platform-build:OLD'
+            ].join('\n');
+
+            const result = fileTransformers['deployment/dockerfile.build'](config, content);
+
+            expect(result).not.toContain('devtool');
+            expect(result).not.toContain('ARG VERSION');
+        });
+
+        it('product modules without version are not treated as FROM in dev environment', () => {
+            const config = makeConfig({
+                modules: [
+                    { name: 'myproduct', type: 'product', devSrc: 'myproduct', isExternal: true, registryProject: 'myproduct' }
+                ]
+            });
+            const content = [
+                '# START SECTION Aliases for Injector images',
+                '# END SECTION',
+                '# START SECTION Copy the modules',
+                '# END SECTION',
+                'FROM harbor/platform-devenv:7.2.0'
+            ].join('\n');
+
+            const result = fileTransformers['.devcontainer/dockerfile'](config, content);
+
+            // In dev, product modules without version should not get a FROM or ARG VERSION
+            expect(result).not.toContain('FROM ${PRODUCT_REGISTRY}myproduct/myproduct');
+            expect(result).not.toContain('ARG VERSION');
+            // No COPY --from either (module is volume-mounted in dev)
+            expect(result).not.toContain('COPY --from=myproduct');
+        });
     });
 
     describe('deployment/dockerfile.appserver', () => {


### PR DESCRIPTION
Modules with `"type": "product"` generate `FROM ... :${VERSION}` and `COPY --from=...` lines in build Dockerfiles (using a VERSION build arg), instead of `COPY --link`. This allows product repos to use these files in pipelines without custom changes and keeps them updatable by the project update tool.

## Changes
- `src/typedef.js`: Added `type` property to Module typedef
- `src/update/transform.js`: Updated `replaceModuleInjection()` to handle product modules

## Jira
PLAT-15928 (subtask of PLAT-15927)