### PR TITLE
Add Vitest tests and CI workflow

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,7 +18,7 @@ module.exports = defineConfig({
         sourceType: 'module'
     },
     plugins: ['prettier', 'n'],
-    ignorePatterns: ['node_modules', 'playground/utils-project-template'],
+    ignorePatterns: ['node_modules', 'playground/utils-project-template', 'tests', 'vitest.config.js'],
     rules: {
         'linebreak-style': ['off', 'unix'],
         'no-console': 'off',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
                 "eslint-plugin-import": "^2.29.1",
                 "eslint-plugin-n": "^17.7.0",
                 "eslint-plugin-prettier": "^5.1.3",
-                "prettier": "^3.2.5"
+                "prettier": "^3.2.5",
+                "vitest": "^4.1.10"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -311,6 +312,40 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -455,6 +490,25 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -490,6 +544,16 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@pkgr/core": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -502,11 +566,282 @@
                 "url": "https://opencollective.com/pkgr"
             }
         },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
             "dev": true
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@trivago/prettier-plugin-sort-imports": {
             "version": "4.3.0",
@@ -530,6 +865,42 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
@@ -764,6 +1135,119 @@
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "dev": true
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -956,6 +1440,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/async-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -1065,6 +1559,16 @@
                 "node": ">=6"
             }
         },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1121,6 +1625,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -1242,6 +1753,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/diff": {
@@ -1394,6 +1915,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -1960,6 +2488,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1967,6 +2505,16 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -2114,6 +2662,21 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -2999,6 +3562,267 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/lightningcss": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3026,6 +3850,16 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
@@ -3090,6 +3924,25 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -3186,6 +4039,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/obug": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/once": {
@@ -3316,6 +4183,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3343,6 +4217,35 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.22",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+            "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.16",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/prelude-ls": {
@@ -3535,6 +4438,40 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rolldown": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.139.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/run-parallel": {
@@ -3762,6 +4699,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3780,6 +4724,30 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -3953,6 +4921,81 @@
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -4034,6 +5077,14 @@
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
             }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -4180,6 +5231,200 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/vite": {
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4278,6 +5523,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "src"
     ],
     "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.12.0"
     },
     "scripts": {
         "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "src"
     ],
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
     },
     "scripts": {
         "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
         "node": ">=18.0.0"
     },
     "scripts": {
+        "test": "vitest run",
+        "test:watch": "vitest",
         "lint": "eslint . --ext .js",
         "link": "npm link && cd ./playground && npm link project-update",
         "playground:update": "cd ./playground && npm run update",
@@ -44,7 +46,8 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-n": "^17.7.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "prettier": "^3.2.5"
+        "prettier": "^3.2.5",
+        "vitest": "^4.1.10"
     },
     "overrides": {
         "minimatch": "^9.0.9"

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readConfig } from '../src/config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, 'fixtures');
+
+describe('readConfig', () => {
+    it('reads and parses the config file', () => {
+        const config = readConfig(fixturesDir);
+
+        expect(config.prefix).toBe('testproj');
+        expect(config.db_name).toBe('testdb');
+        expect(config.display_name).toBe('Test Project');
+        expect(config.version).toBe('0.7.0');
+    });
+
+    it('sets default registry when not specified', () => {
+        const config = readConfig(fixturesDir);
+
+        expect(config.registry).toBe('harbor.delivery.iqgeo.cloud/releases');
+    });
+
+    it('initializes platform arrays if missing', () => {
+        const config = readConfig(fixturesDir);
+
+        expect(config.platform.devenv).toBeInstanceOf(Array);
+        expect(config.platform.appserver).toBeInstanceOf(Array);
+        expect(config.platform.tools).toBeInstanceOf(Array);
+    });
+
+    it('computes shortVersion from module version', () => {
+        const config = readConfig(fixturesDir);
+        const comms = config.modules.find(m => m.name === 'comms');
+
+        expect(comms.shortVersion).toBe('720');
+    });
+
+    it('sets isExternal=true for modules with version', () => {
+        const config = readConfig(fixturesDir);
+        const comms = config.modules.find(m => m.name === 'comms');
+        const custom = config.modules.find(m => m.name === 'custom');
+
+        expect(comms.isExternal).toBe(true);
+        expect(custom.isExternal).toBe(false);
+    });
+
+    it('sets devSrc to module name when no version and no devSrc', () => {
+        const config = readConfig(fixturesDir);
+        const custom = config.modules.find(m => m.name === 'custom');
+
+        expect(custom.devSrc).toBe('custom');
+    });
+
+    it('maps known module schema version names', () => {
+        const config = readConfig(fixturesDir);
+        const comms = config.modules.find(m => m.name === 'comms');
+        const wfm = config.modules.find(m => m.name === 'workflow_manager');
+
+        expect(comms.schemaVersionName).toBe('myw_comms_schema');
+        expect(wfm.schemaVersionName).toBe('mywmywwfm_schema');
+    });
+
+    it('maps registryProject from moduleToProjectMapping', () => {
+        const config = readConfig(fixturesDir);
+        const comms = config.modules.find(m => m.name === 'comms');
+        const custom = config.modules.find(m => m.name === 'custom');
+
+        expect(comms.registryProject).toBe('comms');
+        expect(custom.registryProject).toBe('custom'); // falls back to module name
+    });
+
+    it('adds additional dependencies for network_revenue_optimizer', () => {
+        const config = readConfig(fixturesDir);
+
+        // network_revenue_optimizer adds 'osm' to tools and devenv
+        expect(config.platform.tools).toContain('osm');
+        expect(config.platform.devenv).toContain('osm');
+    });
+
+    it('computes requiredServices from module-to-service mapping', () => {
+        const config = readConfig(fixturesDir);
+
+        // orchestration_manager requires openbao
+        expect(config.requiredServices).toContain('openbao');
+        // notification_manager is a child of workflow_manager, not directly listed
+        // but workflow_manager doesn't have a service mapping
+    });
+
+    it('throws when config file does not exist', () => {
+        expect(() => readConfig('/nonexistent/path')).toThrow();
+    });
+});

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareIqgeorc, mergeCustomSections } from '../src/pull/diff.js';
+
+describe('compareIqgeorc', () => {
+    it('returns empty diffs for identical objects', () => {
+        const template = { prefix: 'test', version: '1.0.0', platform: { version: '7.0' } };
+        const project = { prefix: 'test', version: '1.0.0', platform: { version: '7.0' } };
+
+        const result = compareIqgeorc(project, template);
+
+        expect(result.missingKeys).toEqual([]);
+        expect(result.unexpectedKeys).toEqual([]);
+        expect(result.typeMismatches).toEqual([]);
+    });
+
+    it('detects missing keys in project', () => {
+        const template = { prefix: 'test', version: '1.0.0', db_name: 'mydb' };
+        const project = { prefix: 'test', version: '1.0.0' };
+
+        const result = compareIqgeorc(project, template);
+
+        expect(result.missingKeys).toContain('db_name');
+    });
+
+    it('detects unexpected keys in project', () => {
+        const template = { prefix: 'test' };
+        const project = { prefix: 'test', extra_key: 'value' };
+
+        const result = compareIqgeorc(project, template);
+
+        expect(result.unexpectedKeys).toContain('extra_key');
+    });
+
+    it('detects type mismatches', () => {
+        const template = { prefix: 'test', modules: [] };
+        const project = { prefix: 'test', modules: 'not_an_array' };
+
+        const result = compareIqgeorc(project, template);
+
+        expect(result.typeMismatches).toContain('modules');
+    });
+
+    it('detects nested missing keys', () => {
+        const template = { platform: { version: '7.0', appserver: [] } };
+        const project = { platform: { version: '7.0' } };
+
+        const result = compareIqgeorc(project, template);
+
+        expect(result.missingKeys).toContain('platform.appserver');
+    });
+
+    it('detects nested type mismatches', () => {
+        const template = { platform: { version: '7.0', tools: [] } };
+        const project = { platform: { version: '7.0', tools: 'string' } };
+
+        const result = compareIqgeorc(project, template);
+
+        expect(result.typeMismatches).toContain('platform.tools');
+    });
+
+    it('detects nested unexpected keys', () => {
+        const template = { platform: { version: '7.0' } };
+        const project = { platform: { version: '7.0', extra: true } };
+
+        const result = compareIqgeorc(project, template);
+
+        expect(result.unexpectedKeys).toContain('platform.extra');
+    });
+});
+
+describe('mergeCustomSections', () => {
+    it('preserves template content when no custom sections exist', () => {
+        const template = 'line1\nline2\nline3\n';
+        const project = 'line1\nline2\nline3\n';
+
+        const result = mergeCustomSections(template, project);
+
+        expect(result).toBe(template);
+    });
+
+    it('preserves custom sections from project into template', () => {
+        const template = [
+            'before',
+            '# START CUSTOM SECTION',
+            '# placeholder',
+            '# END CUSTOM SECTION',
+            'after'
+        ].join('\n');
+
+        const project = [
+            'before',
+            '# START CUSTOM SECTION',
+            'my custom content',
+            '# END CUSTOM SECTION',
+            'after'
+        ].join('\n');
+
+        const result = mergeCustomSections(template, project);
+
+        expect(result).toContain('my custom content');
+        expect(result).toContain('# START CUSTOM SECTION');
+        expect(result).toContain('# END CUSTOM SECTION');
+    });
+
+    it('uses // as comment delimiter for jsonc files', () => {
+        const template = [
+            '{',
+            '// START CUSTOM SECTION',
+            '// placeholder',
+            '// END CUSTOM SECTION',
+            '}'
+        ].join('\n');
+
+        const project = [
+            '{',
+            '// START CUSTOM SECTION',
+            '"custom": true',
+            '// END CUSTOM SECTION',
+            '}'
+        ].join('\n');
+
+        const result = mergeCustomSections(template, project, '//');
+
+        expect(result).toContain('"custom": true');
+    });
+
+    it('handles template with no differences returning template as-is', () => {
+        const content = 'identical content\n';
+        const result = mergeCustomSections(content, content, '#');
+
+        expect(result).toBe(content);
+    });
+
+    it('handles multiple custom sections', () => {
+        const template = [
+            'header',
+            '# START CUSTOM SECTION a',
+            '# placeholder a',
+            '# END CUSTOM SECTION',
+            'middle',
+            '# START CUSTOM SECTION b',
+            '# placeholder b',
+            '# END CUSTOM SECTION',
+            'footer'
+        ].join('\n');
+
+        const project = [
+            'header',
+            '# START CUSTOM SECTION a',
+            'custom a content',
+            '# END CUSTOM SECTION',
+            'middle',
+            '# START CUSTOM SECTION b',
+            'custom b content',
+            '# END CUSTOM SECTION',
+            'footer'
+        ].join('\n');
+
+        const result = mergeCustomSections(template, project);
+
+        expect(result).toContain('custom a content');
+        expect(result).toContain('custom b content');
+    });
+});

--- a/tests/fixtures/.iqgeorc.jsonc
+++ b/tests/fixtures/.iqgeorc.jsonc
@@ -1,0 +1,34 @@
+{
+    // Test fixture for readConfig
+    "version": "0.7.0",
+    "prefix": "testproj",
+    "db_name": "testdb",
+    "display_name": "Test Project",
+    "platform": {
+        "version": "7.2.0",
+        "devenv": [],
+        "appserver": ["memcached"],
+        "tools": []
+    },
+    "modules": [
+        {
+            "name": "comms",
+            "version": "7.2.0"
+        },
+        {
+            "name": "workflow_manager",
+            "version": "7.2.0"
+        },
+        {
+            "name": "custom"
+        },
+        {
+            "name": "network_revenue_optimizer",
+            "version": "1.0.0"
+        },
+        {
+            "name": "orchestration_manager",
+            "version": "1.0.0"
+        }
+    ]
+}

--- a/tests/transform.test.js
+++ b/tests/transform.test.js
@@ -1,0 +1,444 @@
+import { describe, expect, it } from 'vitest';
+
+import { fileTransformers } from '../src/update/transform.js';
+
+/** @returns {import('../src/typedef.js').Config} */
+function makeConfig(overrides = {}) {
+    return {
+        prefix: 'myproj',
+        db_name: 'mydb',
+        display_name: 'My Project',
+        version: '0.7.0',
+        registry: 'harbor.delivery.iqgeo.cloud/releases',
+        platform: {
+            version: '7.2.0',
+            devenv: [],
+            appserver: [],
+            tools: []
+        },
+        modules: [
+            {
+                name: 'comms',
+                version: '7.2.0',
+                shortVersion: '720',
+                isExternal: true,
+                registryProject: 'comms',
+                schemaVersionName: 'myw_comms_schema',
+                dbInit: true
+            },
+            {
+                name: 'custom',
+                devSrc: 'custom',
+                isExternal: false,
+                registryProject: 'custom'
+            }
+        ],
+        requiredServices: [],
+        ...overrides
+    };
+}
+
+describe('fileTransformers', () => {
+    describe('.gitignore', () => {
+        it('replaces product modules section with external modules', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION Product modules',
+                '/old_module',
+                '# END SECTION'
+            ].join('\n');
+
+            const result = fileTransformers['.gitignore'](config, content);
+
+            expect(result).toContain('/comms');
+            expect(result).toContain('/dev_tools');
+            expect(result).not.toContain('/old_module');
+        });
+
+        it('adds /custom if not already in modules list', () => {
+            const config = makeConfig({
+                modules: [
+                    { name: 'comms', version: '7.2.0', isExternal: true, registryProject: 'comms' }
+                ]
+            });
+            const content = [
+                '# START SECTION Product modules',
+                '# END SECTION'
+            ].join('\n');
+
+            const result = fileTransformers['.gitignore'](config, content);
+
+            expect(result).toContain('/custom');
+        });
+
+        it('does not duplicate /custom if already in modules', () => {
+            const config = makeConfig({
+                modules: [
+                    {
+                        name: 'custom',
+                        version: '1.0.0',
+                        isExternal: true,
+                        registryProject: 'custom'
+                    }
+                ]
+            });
+            const content = [
+                '# START SECTION Product modules',
+                '# END SECTION'
+            ].join('\n');
+
+            const result = fileTransformers['.gitignore'](config, content);
+
+            const matches = result.match(/\/custom/g);
+            expect(matches).toHaveLength(1);
+        });
+    });
+
+    describe('tsconfig.json', () => {
+        it('adds module paths to compilerOptions.paths', () => {
+            const config = makeConfig();
+            const content = JSON.stringify(
+                { compilerOptions: { paths: {} } },
+                null,
+                4
+            );
+
+            const result = fileTransformers['tsconfig.json'](config, content);
+            const parsed = JSON.parse(result);
+
+            expect(parsed.compilerOptions.paths['modules/comms/*']).toEqual(['./comms/public/*']);
+            expect(parsed.compilerOptions.paths['modules/custom/*']).toEqual([
+                './custom/public/*'
+            ]);
+        });
+
+        it('preserves existing paths', () => {
+            const config = makeConfig();
+            const content = JSON.stringify(
+                { compilerOptions: { paths: { 'existing/*': ['./existing/*'] } } },
+                null,
+                4
+            );
+
+            const result = fileTransformers['tsconfig.json'](config, content);
+            const parsed = JSON.parse(result);
+
+            expect(parsed.compilerOptions.paths['existing/*']).toEqual(['./existing/*']);
+        });
+    });
+
+    describe('.devcontainer/dockerfile', () => {
+        it('replaces platform-devenv version', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION Aliases for Injector images',
+                '# END SECTION',
+                '# START SECTION Copy the modules',
+                '# END SECTION',
+                'FROM harbor.delivery.iqgeo.cloud/releases/platform-devenv-focal:OLD_VERSION'
+            ].join('\n');
+
+            const result = fileTransformers['.devcontainer/dockerfile'](config, content);
+
+            expect(result).toContain('platform-devenv-focal:7.2.0');
+            expect(result).not.toContain('OLD_VERSION');
+        });
+
+        it('injects module aliases and copy statements', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION Aliases for Injector images',
+                '# END SECTION',
+                '# START SECTION Copy the modules',
+                '# END SECTION',
+                'FROM harbor/platform-devenv:1.0.0'
+            ].join('\n');
+
+            const result = fileTransformers['.devcontainer/dockerfile'](config, content);
+
+            expect(result).toContain('FROM ${PRODUCT_REGISTRY}comms/comms:7.2.0 AS comms');
+            expect(result).toContain('COPY --from=comms / ${MODULES}/');
+        });
+    });
+
+    describe('.devcontainer/docker-compose.yml', () => {
+        it('replaces PROJ_PREFIX and MYW_DB_NAME', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION',
+                '# END SECTION',
+                'PROJ_PREFIX: ${PROJ_PREFIX:-old}',
+                'MYW_DB_NAME: ${MYW_DB_NAME:-old}',
+                'iqgeo_old_devserver:'
+            ].join('\n');
+
+            const result = fileTransformers['.devcontainer/docker-compose.yml'](config, content);
+
+            expect(result).toContain('${PROJ_PREFIX:-myproj}');
+            expect(result).toContain('${MYW_DB_NAME:-mydb}');
+            expect(result).toContain('iqgeo_myproj_devserver:');
+        });
+
+        it('injects local module volume mounts', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION',
+                '            - old_mount',
+                '# END SECTION',
+                '${PROJ_PREFIX:-x}',
+                '${MYW_DB_NAME:-x}',
+                'iqgeo_x_devserver:'
+            ].join('\n');
+
+            const result = fileTransformers['.devcontainer/docker-compose.yml'](config, content);
+
+            // custom module has devSrc so should appear as volume mount
+            expect(result).toContain(
+                '../custom:/opt/iqgeo/platform/WebApps/myworldapp/modules/custom:delegated'
+            );
+            expect(result).not.toContain('old_mount');
+        });
+    });
+
+    describe('.devcontainer/.env.example', () => {
+        it('replaces PROJ_PREFIX and MYW_DB_NAME', () => {
+            const config = makeConfig();
+            const content = 'PROJ_PREFIX=old\nMYW_DB_NAME=olddb\n';
+
+            const result = fileTransformers['.devcontainer/.env.example'](config, content);
+
+            expect(result).toContain('PROJ_PREFIX=myproj');
+            expect(result).toContain('MYW_DB_NAME=mydb');
+        });
+    });
+
+    describe('.devcontainer/devcontainer.json', () => {
+        it('replaces name and service', () => {
+            const config = makeConfig();
+            const content = `{
+    "name": "Old Name",
+    "service": "iqgeo_focal_devserver"
+}`;
+
+            const result = fileTransformers['.devcontainer/devcontainer.json'](config, content);
+
+            expect(result).toContain('"name": "My Project"');
+            expect(result).toContain('"service": "iqgeo_myproj_focal_devserver"');
+        });
+    });
+
+    describe('deployment/dockerfile.build', () => {
+        it('replaces platform-build version and injects modules', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION Aliases for Injector images',
+                '# END SECTION',
+                '# START SECTION Copy the modules',
+                '# END SECTION',
+                'FROM harbor/platform-build:OLD'
+            ].join('\n');
+
+            const result = fileTransformers['deployment/dockerfile.build'](config, content);
+
+            expect(result).toContain('platform-build:7.2.0');
+            expect(result).not.toContain('platform-build:OLD');
+        });
+    });
+
+    describe('deployment/dockerfile.appserver', () => {
+        it('replaces platform-appserver version', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION optional dependencies (build)',
+                '# END SECTION',
+                '# START SECTION optional dependencies (runtime)',
+                '# END SECTION',
+                '# START SECTION Copy modules',
+                '# END SECTION',
+                'RUN myw_product fetch pip_packages',
+                'FROM harbor/platform-appserver:OLD',
+                'FROM iqgeo-old-build AS builder',
+                'iqgeo-old-build',
+                'PROJECT_REGISTRY=old_reg',
+                'PROJECT_REPOSITORY=old_repo'
+            ].join('\n');
+
+            const result = fileTransformers['deployment/dockerfile.appserver'](config, content);
+
+            expect(result).toContain('platform-appserver:7.2.0');
+            expect(result).toContain('FROM iqgeo-myproj-build AS builder');
+        });
+
+        it('generates COPY statements for non-devOnly modules', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION optional dependencies (build)',
+                '# END SECTION',
+                '# START SECTION optional dependencies (runtime)',
+                '# END SECTION',
+                '# START SECTION Copy modules',
+                '# END SECTION',
+                'RUN myw_product fetch pip_packages',
+                'FROM harbor/platform-appserver:7.2.0',
+                'FROM iqgeo-old-build AS builder',
+                'iqgeo-old-build',
+                'PROJECT_REGISTRY=',
+                'PROJECT_REPOSITORY='
+            ].join('\n');
+
+            const result = fileTransformers['deployment/dockerfile.appserver'](config, content);
+
+            expect(result).toContain(
+                'COPY --chown=www-data:www-data --from=iqgeo_builder ${MODULES}/comms/ ${MODULES}/comms/'
+            );
+            expect(result).toContain(
+                'COPY --chown=www-data:www-data --from=iqgeo_builder ${MODULES}/custom/ ${MODULES}/custom/'
+            );
+        });
+    });
+
+    describe('deployment/docker-compose.yml', () => {
+        it('replaces prefix and db_name variables', () => {
+            const config = makeConfig();
+            const content = [
+                '${PROJ_PREFIX:-old}',
+                '${MYW_DB_NAME:-old}',
+                '${PROJECT_REGISTRY:-old}',
+                '${PROJECT_REPOSITORY:-old}'
+            ].join('\n');
+
+            const result = fileTransformers['deployment/docker-compose.yml'](config, content);
+
+            expect(result).toContain('${PROJ_PREFIX:-myproj}');
+            expect(result).toContain('${MYW_DB_NAME:-mydb}');
+        });
+    });
+
+    describe('deployment/.env.example', () => {
+        it('replaces environment variables', () => {
+            const config = makeConfig({ deployment: { project_registry: 'reg', project_repository: 'repo' } });
+            const content = 'PROJ_PREFIX=old\nMYW_DB_NAME=old\nPROJECT_REGISTRY=old\nPROJECT_REPOSITORY=old';
+
+            const result = fileTransformers['deployment/.env.example'](config, content);
+
+            expect(result).toContain('PROJ_PREFIX=myproj');
+            expect(result).toContain('MYW_DB_NAME=mydb');
+            expect(result).toContain('PROJECT_REGISTRY=reg');
+            expect(result).toContain('PROJECT_REPOSITORY=repo');
+        });
+    });
+
+    describe('entrypoint.d/600_init_db.sh', () => {
+        it('generates db init commands for modules with dbInit and schemaVersionName', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION db init',
+                'old content',
+                '# END SECTION'
+            ].join('\n');
+
+            const result =
+                fileTransformers['deployment/entrypoint.d/600_init_db.sh'](config, content);
+
+            expect(result).toContain('myw_db $MYW_DB_NAME install comms');
+            expect(result).toContain('grep myw_comms_schema');
+            expect(result).not.toContain('old content');
+        });
+
+        it('skips modules without schemaVersionName', () => {
+            const config = makeConfig({
+                modules: [{ name: 'noschema', version: '1.0', dbInit: true, isExternal: true }]
+            });
+            const content = '# START SECTION db init\n# END SECTION';
+
+            const result =
+                fileTransformers['deployment/entrypoint.d/600_init_db.sh'](config, content);
+
+            expect(result).not.toContain('install noschema');
+        });
+    });
+
+    describe('entrypoint.d/610_upgrade_db.sh', () => {
+        it('generates db upgrade commands', () => {
+            const config = makeConfig();
+            const content = [
+                '# START SECTION db upgrade',
+                'old content',
+                '# END SECTION'
+            ].join('\n');
+
+            const result =
+                fileTransformers['deployment/entrypoint.d/610_upgrade_db.sh'](config, content);
+
+            expect(result).toContain('myw_db $MYW_DB_NAME upgrade comms');
+            expect(result).toContain('grep myw_comms_schema');
+        });
+
+        it('adds colon prefix when section is empty (no modules with db)', () => {
+            const config = makeConfig({
+                modules: [{ name: 'nodeps', isExternal: false, devSrc: 'nodeps' }]
+            });
+            const content = '# START SECTION db upgrade\n# END SECTION';
+
+            const result =
+                fileTransformers['deployment/entrypoint.d/610_upgrade_db.sh'](config, content);
+
+            // Should have a colon as no-op when empty
+            expect(result).toMatch(/# START SECTION db upgrade\n:\n# END SECTION/);
+        });
+    });
+
+    describe('deployment/build_images.sh', () => {
+        it('replaces PROJ_PREFIX and deployment vars', () => {
+            const config = makeConfig({
+                deployment: { project_registry: 'myreg', project_repository: 'myrepo' }
+            });
+            const content =
+                'PROJ_PREFIX="old"\nPROJECT_REGISTRY="oldreg"\nPROJECT_REPOSITORY="oldrepo"';
+
+            const result = fileTransformers['deployment/build_images.sh'](config, content);
+
+            expect(result).toContain('PROJ_PREFIX="myproj"');
+            expect(result).toContain('PROJECT_REGISTRY="myreg"');
+            expect(result).toContain('PROJECT_REPOSITORY="myrepo"');
+        });
+    });
+
+    describe('deployment/values.yaml', () => {
+        it('replaces imagePrefix and project vars', () => {
+            const config = makeConfig({
+                deployment: { project_registry: 'reg', project_repository: 'repo' }
+            });
+            const content = 'imagePrefix: old\nprojectRegistry: old\nprojectRepository: old\n';
+
+            const result = fileTransformers['deployment/values.yaml'](config, content);
+
+            expect(result).toContain('imagePrefix: myproj');
+            expect(result).toContain('projectRegistry: reg');
+            expect(result).toContain('projectRepository: repo');
+        });
+    });
+});
+
+describe('enableServices', () => {
+    it('removes profiles disabled and adds to depends_on', () => {
+        const config = makeConfig({ requiredServices: ['openbao'] });
+        const content = [
+            'services:',
+            '    openbao:',
+            "        profiles: ['disabled']",
+            '        image: openbao',
+            '    iqgeo:',
+            '        image: iqgeo',
+            '        depends_on:',
+            '            - postgres',
+            '    other:',
+            '        image: other'
+        ].join('\n');
+
+        const result = fileTransformers['deployment/docker-compose.yml'](config, content);
+
+        expect(result).not.toContain("profiles: ['disabled']");
+        expect(result).toContain('            - openbao');
+    });
+});

--- a/tests/update.test.js
+++ b/tests/update.test.js
@@ -66,7 +66,7 @@ describe('update', () => {
         expect(result).not.toContain('/old');
     });
 
-    it('reports success via progress.log', () => {
+    it('does not report errors when config is valid', () => {
         writeConfig({
             version: '0.7.0',
             prefix: 'test',

--- a/tests/update.test.js
+++ b/tests/update.test.js
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { update } from '../src/update/index.js';
+
+describe('update', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'update-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeConfig(config) {
+        const content = JSON.stringify(config);
+        fs.writeFileSync(path.join(tmpDir, '.iqgeorc.jsonc'), content);
+    }
+
+    function writeFile(relPath, content) {
+        const filePath = path.join(tmpDir, relPath);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, content);
+    }
+
+    it('calls progress.error when config file is missing', () => {
+        const progress = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+        update({ root: tmpDir, progress });
+
+        expect(progress.error).toHaveBeenCalledWith(
+            1,
+            'Failed to read configuration file',
+            expect.anything()
+        );
+    });
+
+    it('updates .gitignore from config', () => {
+        writeConfig({
+            version: '0.7.0',
+            prefix: 'test',
+            db_name: 'testdb',
+            platform: { version: '7.0.0', devenv: [], appserver: [], tools: [] },
+            modules: [
+                { name: 'comms', version: '7.0.0' },
+                { name: 'mymod' }
+            ]
+        });
+
+        writeFile(
+            '.gitignore',
+            'node_modules\n# START SECTION Product modules\n/old\n# END SECTION\n'
+        );
+
+        const progress = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+        update({ root: tmpDir, progress });
+
+        const result = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf8');
+        expect(result).toContain('/comms');
+        expect(result).toContain('/dev_tools');
+        expect(result).toContain('/custom');
+        expect(result).not.toContain('/old');
+    });
+
+    it('reports success via progress.log', () => {
+        writeConfig({
+            version: '0.7.0',
+            prefix: 'test',
+            db_name: 'testdb',
+            platform: { version: '7.0.0', devenv: [], appserver: [], tools: [] },
+            modules: []
+        });
+
+        const progress = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+        update({ root: tmpDir, progress });
+
+        // Should log success (may also warn about missing files)
+        expect(progress.error).not.toHaveBeenCalled();
+    });
+
+    it('respects exclude_file_paths configuration', () => {
+        writeConfig({
+            version: '0.7.0',
+            prefix: 'test',
+            db_name: 'testdb',
+            platform: { version: '7.0.0', devenv: [], appserver: [], tools: [] },
+            modules: [],
+            exclude_file_paths: ['\\.gitignore']
+        });
+
+        writeFile(
+            '.gitignore',
+            'node_modules\n# START SECTION Product modules\n/should_remain\n# END SECTION\n'
+        );
+
+        const progress = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+        update({ root: tmpDir, progress });
+
+        const result = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf8');
+        expect(result).toContain('/should_remain');
+    });
+
+    it('warns when a file cannot be read', () => {
+        writeConfig({
+            version: '0.7.0',
+            prefix: 'test',
+            db_name: 'testdb',
+            platform: { version: '7.0.0', devenv: [], appserver: [], tools: [] },
+            modules: []
+        });
+        // Don't create any files that the transformers expect
+
+        const progress = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+        update({ root: tmpDir, progress });
+
+        // Should warn about missing files but not error
+        expect(progress.warn).toHaveBeenCalled();
+        expect(progress.error).not.toHaveBeenCalled();
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        root: '.'
+    }
+});


### PR DESCRIPTION
## Summary

Introduces a test framework and comprehensive unit tests for the existing codebase, plus a GitHub Actions CI workflow to run checks on PRs.

## Changes

### Test Framework Setup
- Install **Vitest** as dev dependency
- Add `npm test` and `npm run test:watch` scripts
- Add `vitest.config.js`
- Update `.eslintrc.cjs` to ignore test files

### Tests (51 total)
| File | Tests | Coverage |
|------|-------|----------|
| `tests/diff.test.js` | 12 | `compareIqgeorc` schema diffing + `mergeCustomSections` |
| `tests/transform.test.js` | 23 | File transformers (.gitignore, tsconfig, dockerfiles, docker-compose, env, db scripts, deployment) |
| `tests/config.test.js` | 11 | `readConfig` (defaults, module enrichment, schema/registry/service mapping) |
| `tests/update.test.js` | 5 | Update orchestration (error handling, file exclusion, progress reporting) |

### CI Workflow (`.github/workflows/ci.yml`)
- Triggers on PRs to `main`
- Runs test suite on Node 24 (matches VS Code's Electron 42 runtime)

### Engine requirement
- Bumped `engines.node` to `>=22.12.0` to align with Vite's requirements

## Not in scope
- `pull/index.js` (requires git clone from GitHub — integration test territory)